### PR TITLE
Exclude /etc/cni/net.d from cleanup to preserve non k8s networks

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -213,13 +213,12 @@ func (r *HostReconciler) SetupWithManager(ctx context.Context, mgr manager.Manag
 		Complete(r)
 }
 
-// cleanup /run/kubeadm, /etc/cni/net.d dirs to remove any stale config on the host
+// cleanup /run/kubeadm dirs to remove any stale config on the host
 func (r *HostReconciler) cleank8sdirectories(ctx context.Context) error {
 	logger := ctrl.LoggerFrom(ctx)
 
 	dirs := []string{
 		"/run/kubeadm/*",
-		"/etc/cni/net.d/*",
 	}
 
 	errList := make([]error, 0)


### PR DESCRIPTION
**What this PR does / why we need it**:
Excludes /etc/cni/net.d from cleanup logic to prevent accidental deletion of network configurations that lie outside the Kubernetes stack. This directory is already managed by internal orchestration, and purging it risks impacting third-party or system-managed networks beyond Kubernetes's scope.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #13 

**Additional information**
- Cleanup previously assumed full ownership of /etc/cni/net.d, leading to unintended regressions in BYOH setups.
- This change ensures better isolation between Kubernetes lifecycle hooks and broader system networking.

**Special notes for your reviewer**
Please verify that similar shared directories aren’t inadvertently affected by the cleanup process. Also, feel free to suggest guardrails for directory ownership to avoid future regressions.

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->