### PR TITLE
remove infrastructure- prefix from all the rbac files

### DIFF
--- a/config/rbac/infrastructure_bootstrapkubeconfig_admin_role.yaml
+++ b/config/rbac/infrastructure_bootstrapkubeconfig_admin_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-bootstrapkubeconfig-admin-role
+  name: bootstrapkubeconfig-admin-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_bootstrapkubeconfig_editor_role.yaml
+++ b/config/rbac/infrastructure_bootstrapkubeconfig_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-bootstrapkubeconfig-editor-role
+  name: bootstrapkubeconfig-editor-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_bootstrapkubeconfig_viewer_role.yaml
+++ b/config/rbac/infrastructure_bootstrapkubeconfig_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-bootstrapkubeconfig-viewer-role
+  name: bootstrapkubeconfig-viewer-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byocluster_admin_role.yaml
+++ b/config/rbac/infrastructure_byocluster_admin_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byocluster-admin-role
+  name: byocluster-admin-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byocluster_editor_role.yaml
+++ b/config/rbac/infrastructure_byocluster_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byocluster-editor-role
+  name: byocluster-editor-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byocluster_viewer_role.yaml
+++ b/config/rbac/infrastructure_byocluster_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byocluster-viewer-role
+  name: byocluster-viewer-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byoclustertemplate_admin_role.yaml
+++ b/config/rbac/infrastructure_byoclustertemplate_admin_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byoclustertemplate-admin-role
+  name: byoclustertemplate-admin-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byoclustertemplate_editor_role.yaml
+++ b/config/rbac/infrastructure_byoclustertemplate_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byoclustertemplate-editor-role
+  name: byoclustertemplate-editor-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byoclustertemplate_viewer_role.yaml
+++ b/config/rbac/infrastructure_byoclustertemplate_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byoclustertemplate-viewer-role
+  name: byoclustertemplate-viewer-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byohost_admin_role.yaml
+++ b/config/rbac/infrastructure_byohost_admin_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byohost-admin-role
+  name: byohost-admin-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byohost_editor_clusterrolebinding.yaml
+++ b/config/rbac/infrastructure_byohost_editor_clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infrastructure-byohost-editor-role
+  name: byohost-editor-role
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/rbac/infrastructure_byohost_editor_role.yaml
+++ b/config/rbac/infrastructure_byohost_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byohost-editor-role
+  name: byohost-editor-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byohost_viewer_role.yaml
+++ b/config/rbac/infrastructure_byohost_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byohost-viewer-role
+  name: byohost-viewer-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byomachine_admin_role.yaml
+++ b/config/rbac/infrastructure_byomachine_admin_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byomachine-admin-role
+  name: byomachine-admin-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byomachine_editor_role.yaml
+++ b/config/rbac/infrastructure_byomachine_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byomachine-editor-role
+  name: byomachine-editor-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byomachine_viewer_role.yaml
+++ b/config/rbac/infrastructure_byomachine_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byomachine-viewer-role
+  name: byomachine-viewer-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byomachinetemplate_admin_role.yaml
+++ b/config/rbac/infrastructure_byomachinetemplate_admin_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byomachinetemplate-admin-role
+  name: byomachinetemplate-admin-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byomachinetemplate_editor_role.yaml
+++ b/config/rbac/infrastructure_byomachinetemplate_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byomachinetemplate-editor-role
+  name: byomachinetemplate-editor-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_byomachinetemplate_viewer_role.yaml
+++ b/config/rbac/infrastructure_byomachinetemplate_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-byomachinetemplate-viewer-role
+  name: byomachinetemplate-viewer-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_k8sinstallerconfig_admin_role.yaml
+++ b/config/rbac/infrastructure_k8sinstallerconfig_admin_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-k8sinstallerconfig-admin-role
+  name: k8sinstallerconfig-admin-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_k8sinstallerconfig_editor_role.yaml
+++ b/config/rbac/infrastructure_k8sinstallerconfig_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-k8sinstallerconfig-editor-role
+  name: k8sinstallerconfig-editor-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_k8sinstallerconfig_viewer_role.yaml
+++ b/config/rbac/infrastructure_k8sinstallerconfig_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-k8sinstallerconfig-viewer-role
+  name: k8sinstallerconfig-viewer-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_k8sinstallerconfigtemplate_admin_role.yaml
+++ b/config/rbac/infrastructure_k8sinstallerconfigtemplate_admin_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-k8sinstallerconfigtemplate-admin-role
+  name: k8sinstallerconfigtemplate-admin-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_k8sinstallerconfigtemplate_editor_role.yaml
+++ b/config/rbac/infrastructure_k8sinstallerconfigtemplate_editor_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-k8sinstallerconfigtemplate-editor-role
+  name: k8sinstallerconfigtemplate-editor-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/config/rbac/infrastructure_k8sinstallerconfigtemplate_viewer_role.yaml
+++ b/config/rbac/infrastructure_k8sinstallerconfigtemplate_viewer_role.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/name: byoh
     app.kubernetes.io/managed-by: kustomize
-  name: infrastructure-k8sinstallerconfigtemplate-viewer-role
+  name: k8sinstallerconfigtemplate-viewer-role
 rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io


### PR DESCRIPTION
As part of this PR, we are removing infrastructure- prefix from all the files as byoh upgrade is failing from v0.5.x to v0.8.x due to mismatch of roleRef in the clusterRoleBinding

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->