### PR TITLE
refactor: move CleanupKubelet function from util to HostReconciler

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	infrastructurev1beta1 "github.com/cohesity/cluster-api-provider-bringyourownhost/api/infrastructure/v1beta1"
-	byohutil "github.com/cohesity/cluster-api-provider-bringyourownhost/util"
 	byohruntime "github.com/cohesity/cluster-api-provider-bringyourownhost/util/runtime"
 	"github.com/kube-vip/kube-vip/pkg/vip"
 )
@@ -46,6 +45,11 @@ const (
 	bootstrapSentinelFile = "/run/cluster-api/bootstrap-success.complete"
 	// KubeadmResetCommand is the command to run to force reset/remove nodes' local file system of the files created by kubeadm
 	KubeadmResetCommand = "kubeadm reset --force --v=5"
+
+	// Kubelet cleanup commands
+	removeKubeletBinaryCmd       = "rm -f /usr/bin/kubelet"
+	checkKubeletServiceActiveCmd = "systemctl is-active --quiet kubelet"
+	stopKubeletServiceCmd        = "systemctl stop kubelet"
 )
 
 // errContainerRuntimeNil is returned when container runtime is nil
@@ -344,7 +348,7 @@ func (r *HostReconciler) bootstrapK8sNode(ctx context.Context, bootstrapScript s
 
 func (r *HostReconciler) removeContainers(ctx context.Context) error {
 	// Cleanup kubelet before removing containers
-	err := byohutil.CleanupKubelet(ctx, r.CmdRunner)
+	err := r.cleanupKubelet(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to cleanup kubelet: %w", err)
 	}
@@ -467,6 +471,33 @@ func (r *HostReconciler) checkAndPopulateUninstallScriptFromInstallSecret(ctx co
 	}
 
 	byoHost.Spec.UninstallationScript = &uninstallScript
+
+	return nil
+}
+
+// CleanupKubelet removes the kubelet binary and stops the kubelet service
+func (r *HostReconciler) cleanupKubelet(ctx context.Context) error {
+	logger := ctrl.LoggerFrom(ctx)
+
+	// First remove kubelet binary
+	logger.Info("Removing kubelet binary")
+	if err := r.CmdRunner.RunCmd(ctx, removeKubeletBinaryCmd); err != nil {
+		return fmt.Errorf("failed to remove kubelet binary: %w", err)
+	}
+
+	// Check if kubelet service is running before stopping it
+	logger.Info("Checking if kubelet service is active")
+	if err := r.CmdRunner.RunCmd(ctx, checkKubeletServiceActiveCmd); err != nil {
+		// Service is not active, skip stopping it
+		logger.Info("Kubelet service is not active, skipping stop")
+		return nil
+	}
+
+	// Service is active, stop it
+	logger.Info("Stopping kubelet service")
+	if err := r.CmdRunner.RunCmd(ctx, stopKubeletServiceCmd); err != nil {
+		return fmt.Errorf("failed to stop kubelet service: %w", err)
+	}
 
 	return nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -12,20 +12,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/cohesity/cluster-api-provider-bringyourownhost/agent/cloudinit"
 	infrastructurev1beta1 "github.com/cohesity/cluster-api-provider-bringyourownhost/api/infrastructure/v1beta1"
 )
 
 const (
 	// ByoMachineKind is the Kind for ByoMachine
 	ByoMachineKind = "ByoMachine"
-
-	// Kubelet cleanup commands
-	RemoveKubeletBinaryCmd = "rm -f /usr/bin/kubelet"
-	StopKubeletServiceCmd  = "systemctl stop kubelet || true"
 )
 
 var (
@@ -107,23 +101,4 @@ func GetByoMachineForHost(ctx context.Context, c client.Client, byoHost *infrast
 	}
 
 	return byoMachine, nil
-}
-
-// CleanupKubelet removes the kubelet binary and stops the kubelet service
-func CleanupKubelet(ctx context.Context, cmdRunner cloudinit.ICmdRunner) error {
-	logger := ctrl.LoggerFrom(ctx)
-
-	// First remove kubelet binary
-	logger.Info("Removing kubelet binary")
-	if err := cmdRunner.RunCmd(ctx, RemoveKubeletBinaryCmd); err != nil {
-		return fmt.Errorf("failed to remove kubelet binary: %w", err)
-	}
-
-	// Then stop kubelet service
-	logger.Info("Stopping kubelet service")
-	if err := cmdRunner.RunCmd(ctx, StopKubeletServiceCmd); err != nil {
-		return fmt.Errorf("failed to stop kubelet service: %w", err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
move cleanupkubelet function from util to host agent,as byoh controller image depends on agent. To remove the dependency we need to move the function from util to agent.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->